### PR TITLE
finalize swagger-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,12 @@ await fastify.ready()
 
  | Option             | Default          | Description                                                                                                               |
  | ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
+ | baseDir            | undefined        | Specify the directory where all spec files that are included in the main one using $ref will be located. By default, this is the directory where the main spec file is located. Provided value should be an absolute path without trailing slash.     |
  | initOAuth          | {}               | Configuration options for [Swagger UI initOAuth](https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/).     |
- | routePrefix         | '/documentation' | Overwrite the default Swagger UI route prefix.                                                                            |
+ | routePrefix        | '/documentation' | Overwrite the default Swagger UI route prefix.                                                                            |
  | staticCSP          | false            | Enable CSP header for static resources.                                                                                   |
  | transformStaticCSP | undefined         | Synchronous function to transform CSP header for static resources if the header has been previously set.                  |
- | uiConfig            | {}               | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md). Must be literal values, see [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).|
+ | uiConfig           | {}               | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md). Must be literal values, see [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).|
  | uiHooks            | {}               | Additional hooks for the documentation's routes. You can provide the `onRequest` and `preHandler` hooks with the same [route's options](https://www.fastify.io/docs/latest/Routes/#options) interface.|
 
 The plugin will expose the documentation with the following APIs:

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const fp = require('fastify-plugin')
 function fastifySwaggerUi (fastify, opts, next) {
   fastify.decorate('swaggerCSP', require('./dist/csp.json'))
 
+  const baseDir = opts.baseDir
   const prefix = opts.routePrefix || '/documentation'
   const uiConfig = opts.uiConfig || {}
   const initOAuth = opts.initOAuth || {}
@@ -13,6 +14,7 @@ function fastifySwaggerUi (fastify, opts, next) {
   const hooks = opts.uiHooks
 
   fastify.register(require('./lib/routes'), {
+    baseDir,
     prefix,
     uiConfig,
     initOAuth,
@@ -26,5 +28,6 @@ function fastifySwaggerUi (fastify, opts, next) {
 
 module.exports = fp(fastifySwaggerUi, {
   fastify: '4.x',
-  name: '@fastify/swagger-ui'
+  name: '@fastify/swagger-ui',
+  dependencies: ['@fastify/swagger']
 })

--- a/test/csp.test.js
+++ b/test/csp.test.js
@@ -3,6 +3,7 @@
 const { test } = require('tap')
 const Fastify = require('fastify')
 const fastifyHelmet = require('@fastify/helmet')
+const fastifySwagger = require('@fastify/swagger')
 const fastifySwaggerUi = require('..')
 const {
   schemaQuerystring,
@@ -17,7 +18,9 @@ test('staticCSP = undefined', async (t) => {
   t.plan(3)
 
   const fastify = Fastify()
-  await fastify.register(fastifySwaggerUi, swaggerOption)
+
+  await fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwaggerUi)
 
   fastify.get('/', () => {})
   fastify.post('/', () => {})
@@ -39,8 +42,8 @@ test('staticCSP = true', async (t) => {
   t.plan(5)
 
   const fastify = Fastify()
+  await fastify.register(fastifySwagger, swaggerOption)
   await fastify.register(fastifySwaggerUi, {
-    ...swaggerOption,
     staticCSP: true
   })
 
@@ -75,8 +78,8 @@ test('staticCSP = "default-src \'self\';"', async (t) => {
   t.plan(5)
 
   const fastify = Fastify()
+  await fastify.register(fastifySwagger, swaggerOption)
   await fastify.register(fastifySwaggerUi, {
-    ...swaggerOption,
     staticCSP: "default-src 'self';"
   })
 
@@ -111,8 +114,8 @@ test('staticCSP = object', async (t) => {
   t.plan(5)
 
   const fastify = Fastify()
+  await fastify.register(fastifySwagger, swaggerOption)
   await fastify.register(fastifySwaggerUi, {
-    ...swaggerOption,
     staticCSP: {
       'default-src': ["'self'"],
       'script-src': "'self'"
@@ -150,8 +153,8 @@ test('transformStaticCSP = function', async (t) => {
   t.plan(6)
 
   const fastify = Fastify()
+  await fastify.register(fastifySwagger, swaggerOption)
   await fastify.register(fastifySwaggerUi, {
-    ...swaggerOption,
     staticCSP: "default-src 'self';",
     transformStaticCSP: function (header) {
       t.equal(header, "default-src 'self';")
@@ -191,8 +194,8 @@ test('transformStaticCSP = function, with @fastify/helmet', async (t) => {
 
   const fastify = Fastify()
   fastify.register(fastifyHelmet)
+  await fastify.register(fastifySwagger, swaggerOption)
   await fastify.register(fastifySwaggerUi, {
-    ...swaggerOption,
     transformStaticCSP: function (header) {
       t.equal(header, "default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests")
       return "default-src 'self'; script-src 'self';"

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -2,12 +2,14 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
+const fastifySwagger = require('@fastify/swagger')
 const fastifySwaggerUi = require('../index')
 
 test('fastify.swaggerCSP should exist', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
+  await fastify.register(fastifySwagger)
   await fastify.register(fastifySwaggerUi)
 
   await fastify.ready()

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -3,11 +3,9 @@
 const { test } = require('tap')
 const Fastify = require('fastify')
 const fastifySwagger = require('@fastify/swagger')
-const fastifySwaggerUi = require('..')
+const fastifySwaggerUi = require('../index')
 const yaml = require('yaml')
-// const path = require('path')
-// const Swagger = require('@apidevtools/swagger-parser')
-// const readFileSync = require('fs').readFileSync
+const readFileSync = require('fs').readFileSync
 const resolve = require('path').resolve
 
 test('swagger route returns yaml', async (t) => {
@@ -121,53 +119,57 @@ test('swagger route returns explicitly passed doc', async (t) => {
   t.pass('valid explicitly passed spec document')
 })
 
-// test('/documentation/:file should serve static file from the location of main specification file', async (t) => {
-//   const config = {
-//     mode: 'static',
-//     specification: {
-//       path: './examples/example-static-specification.yaml'
-//     }
-//   }
+test('/documentation/:file should serve static file from the location of main specification file', async (t) => {
+  const config = {
+    mode: 'static',
+    specification: {
+      path: './examples/example-static-specification.yaml'
+    }
+  }
 
-//   t.plan(4)
-//   const fastify = new Fastify()
-//   await fastify.register(fastifySwagger, config)
-//   await fastify.register(fastifySwaggerUi)
+  const uiConfig = {
+    baseDir: resolve(__dirname, '..', 'examples')
+  }
 
-//   {
-//     const res = await fastify.inject({
-//       method: 'GET',
-//       url: '/documentation/non-existing-file'
-//     })
+  t.plan(4)
+  const fastify = new Fastify()
+  await fastify.register(fastifySwagger, config)
+  await fastify.register(fastifySwaggerUi, uiConfig)
 
-//     t.equal(res.statusCode, 404)
-//   }
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/non-existing-file'
+    })
 
-//   {
-//     const res = await fastify.inject({
-//       method: 'GET',
-//       url: '/documentation/example-static-specification.yaml'
-//     })
+    t.equal(res.statusCode, 404)
+  }
 
-//     t.equal(res.statusCode, 200)
-//     t.equal(
-//       readFileSync(
-//         resolve(__dirname, '..', '..', 'examples', 'example-static-specification.yaml'),
-//         'utf8'
-//       ),
-//       res.payload
-//     )
-//   }
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/example-static-specification.yaml'
+    })
 
-//   {
-//     const res = await fastify.inject({
-//       method: 'GET',
-//       url: '/documentation/dynamic-swagger.js'
-//     })
+    t.equal(res.statusCode, 200)
+    t.equal(
+      readFileSync(
+        resolve(__dirname, '..', 'examples', 'example-static-specification.yaml'),
+        'utf8'
+      ),
+      res.payload
+    )
+  }
 
-//     t.equal(res.statusCode, 200)
-//   }
-// })
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/dynamic-swagger.js'
+    })
+
+    t.equal(res.statusCode, 200)
+  }
+})
 
 test('/documentation/non-existing-file calls custom NotFoundHandler', async (t) => {
   const config = {
@@ -193,58 +195,65 @@ test('/documentation/non-existing-file calls custom NotFoundHandler', async (t) 
   t.equal(res.statusCode, 410)
 })
 
-// test('/documentation/:file should be served from custom location', async (t) => {
-//   const config = {
-//     mode: 'static',
-//     specification: {
-//       path: './examples/example-static-specification.yaml',
-//       baseDir: resolve(__dirname, '..', 'dist')
-//     }
-//   }
+test('/documentation/:file should be served from custom location', async (t) => {
+  const config = {
+    mode: 'static',
+    specification: {
+      path: './examples/example-static-specification.yaml',
+      baseDir: resolve(__dirname, '..', 'dist')
+    }
+  }
 
-//   t.plan(2)
-//   const fastify = new Fastify()
-//   await fastify.register(fastifySwagger, config)
-//   await fastify.register(fastifySwaggerUi)
+  const uiConfig = {
+    baseDir: resolve(__dirname, '..', 'dist')
+  }
 
-//   const res = await fastify.inject({
-//     method: 'GET',
-//     url: '/documentation/oauth2-redirect.html'
-//   })
+  t.plan(2)
+  const fastify = new Fastify()
+  await fastify.register(fastifySwagger, config)
+  await fastify.register(fastifySwaggerUi, uiConfig)
 
-//   const fileContent = readFileSync(resolve(__dirname, '..', 'dist', 'oauth2-redirect.html'), 'utf8')
-//   t.equal(res.statusCode, 200)
-//   t.equal(
-//     fileContent,
-//     res.payload
-//   )
-// })
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/documentation/oauth2-redirect.html'
+  })
 
-// test('/documentation/:file should be served from custom location with trailing slash(es)', async (t) => {
-//   const config = {
-//     mode: 'static',
-//     specification: {
-//       path: './examples/example-static-specification.yaml',
-//       baseDir: resolve(__dirname, '..', '..', 'dist') + '/'
-//     }
-//   }
+  const fileContent = readFileSync(resolve(__dirname, '..', 'dist', 'oauth2-redirect.html'), 'utf8')
+  t.equal(res.statusCode, 200)
+  t.equal(
+    fileContent,
+    res.payload
+  )
+})
 
-//   t.plan(2)
-//   const fastify = new Fastify()
-//   await fastify.register(fastifySwagger, config)
-//   await fastify.register(fastifySwaggerUi)
+test('/documentation/:file should be served from custom location with trailing slash(es)', async (t) => {
+  const config = {
+    mode: 'static',
+    specification: {
+      path: './examples/example-static-specification.yaml'
+    }
+  }
 
-//   const res = await fastify.inject({
-//     method: 'GET',
-//     url: '/documentation/oauth2-redirect.html'
-//   })
+  const uiConfig = {
+    baseDir: resolve(__dirname, '..', 'dist') + '/'
+  }
 
-//   t.equal(res.statusCode, 200)
-//   t.equal(
-//     readFileSync(resolve(__dirname, '..', '..', 'dist', 'oauth2-redirect.html'), 'utf8'),
-//     res.payload
-//   )
-// })
+  t.plan(2)
+  const fastify = new Fastify()
+  await fastify.register(fastifySwagger, config)
+  await fastify.register(fastifySwaggerUi, uiConfig)
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/documentation/oauth2-redirect.html'
+  })
+
+  t.equal(res.statusCode, 200)
+  t.equal(
+    readFileSync(resolve(__dirname, '..', 'dist', 'oauth2-redirect.html'), 'utf8'),
+    res.payload
+  )
+})
 
 test('/documentation/yaml returns cache.swaggerString on second request in static mode', async (t) => {
   const config = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,6 +29,7 @@ declare module 'fastify' {
 export const fastifySwaggerUi: FastifyPluginCallback<FastifySwaggerUiOptions>;
 
 export interface FastifySwaggerUiOptions {
+  baseDir?: string;
   /**
    * Overwrite the swagger url end-point
    * @default /documentation


### PR DESCRIPTION
add baseDir Option
reactivate tests

This PR reactivates the unit tests as I mentioned in #1 were missing. 

I will now get the test coverage in the corresponding fastify-swagger ui removal PR done. 

@mcollina 
Please dont release yet. I recommend following plan: 

- get this merged
- fix the PR in fastify-swagger, get it merged
- get a new major release of fastify-swagger
- change in the package.json of this repo to point to fastify-swagger on npm to the new version
- get this package released

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
