### PR TITLE
feat: allow to define route log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ await fastify.ready()
  | transformStaticCSP | undefined         | Synchronous function to transform CSP header for static resources if the header has been previously set.                  |
  | uiConfig           | {}               | Configuration options for [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md). Must be literal values, see [#5710](https://github.com/swagger-api/swagger-ui/issues/5710).|
  | uiHooks            | {}               | Additional hooks for the documentation's routes. You can provide the `onRequest` and `preHandler` hooks with the same [route's options](https://www.fastify.io/docs/latest/Routes/#options) interface.|
+ | logLevel           | info             | Allow to define route log level.|
 
 The plugin will expose the documentation with the following APIs:
 

--- a/examples/static-yaml-file.js
+++ b/examples/static-yaml-file.js
@@ -9,7 +9,7 @@ fastify.register(require('@fastify/swagger'), {
   }
 })
 
-fastify.reqister(require('../index'))
+fastify.register(require('../index'))
 
 fastify.listen({ port: 3000 }, (err) => {
   if (err) throw err

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function fastifySwaggerUi (fastify, opts, next) {
   const staticCSP = opts.staticCSP
   const transformStaticCSP = opts.transformStaticCSP
   const hooks = opts.uiHooks
+  const logLevel = opts.logLevel
 
   fastify.register(require('./lib/routes'), {
     baseDir,
@@ -20,7 +21,8 @@ function fastifySwaggerUi (fastify, opts, next) {
     initOAuth,
     staticCSP,
     transformStaticCSP,
-    hooks
+    hooks,
+    logLevel
   })
 
   next()

--- a/index.js
+++ b/index.js
@@ -6,14 +6,11 @@ function fastifySwaggerUi (fastify, opts, next) {
   fastify.decorate('swaggerCSP', require('./static/csp.json'))
 
   fastify.register(require('./lib/routes'), {
-    baseDir: opts.baseDir,
     prefix: opts.routePrefix || '/documentation',
     uiConfig: opts.uiConfig || {},
     initOAuth: opts.initOAuth || {},
-    staticCSP: opts.staticCSP,
-    transformStaticCSP: opts.transformStaticCSP,
     hooks: opts.uiHooks,
-    logLevel: opts.logLevel
+    ...opts
   })
 
   next()

--- a/index.js
+++ b/index.js
@@ -5,24 +5,15 @@ const fp = require('fastify-plugin')
 function fastifySwaggerUi (fastify, opts, next) {
   fastify.decorate('swaggerCSP', require('./static/csp.json'))
 
-  const baseDir = opts.baseDir
-  const prefix = opts.routePrefix || '/documentation'
-  const uiConfig = opts.uiConfig || {}
-  const initOAuth = opts.initOAuth || {}
-  const staticCSP = opts.staticCSP
-  const transformStaticCSP = opts.transformStaticCSP
-  const hooks = opts.uiHooks
-  const logLevel = opts.logLevel
-
   fastify.register(require('./lib/routes'), {
-    baseDir,
-    prefix,
-    uiConfig,
-    initOAuth,
-    staticCSP,
-    transformStaticCSP,
-    hooks,
-    logLevel
+    baseDir: opts.baseDir,
+    prefix: opts.routePrefix || '/documentation',
+    uiConfig: opts.uiConfig || {},
+    initOAuth: opts.initOAuth || {},
+    staticCSP: opts.staticCSP,
+    transformStaticCSP: opts.transformStaticCSP,
+    hooks: opts.uiHooks,
+    logLevel: opts.logLevel
   })
 
   next()

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -530,3 +530,39 @@ test('/documentation/ should redirect to ./static/index.html', async (t) => {
   t.equal(res.statusCode, 302)
   t.equal(res.headers.location, './static/index.html')
 })
+
+test('should return silent log level of route /documentation', async (t) => {
+  const fastify = Fastify()
+
+  fastify.addHook('onRoute', function (route) {
+    t.equal(route.logLevel, 'silent')
+  })
+
+  await fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwaggerUi, { logLevel: 'silent' })
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/documentation/'
+  })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './static/index.html')
+})
+
+test('should return empty log level of route /documentation', async (t) => {
+  const fastify = Fastify()
+
+  fastify.addHook('onRoute', function (route) {
+    t.equal(route.logLevel, '')
+  })
+
+  await fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwaggerUi)
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/documentation/'
+  })
+  t.equal(res.statusCode, 302)
+  t.equal(res.headers.location, './static/index.html')
+})


### PR DESCRIPTION
The purpose of this PR is to allow to define a specific log level in scenarios when we want to silent all logs of the swagger route.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
