### PR TITLE
Add docs for protecting the documentation routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,35 @@ await fastify.register(require('@fastify/swagger-ui'), {
 })
 ```
 
+#### Protect your documentation routes
+
+You can protect your documentation by configuring an authentication hook.
+Here is an example using the [`@fastify/basic-auth`](https://github.com/fastify/fastify-basic-auth) plugin:
+
+##### Example
+```js
+const fastify = require('fastify')()
+
+fastify.register(require('@fastify/swagger'))
+
+await fastify.register(require('@fastify/basic-auth'), {
+  validate (username, password, req, reply, done) {
+    if (username === 'admin' && password === 'admin') {
+      done()
+    } else {
+      done(new Error('You can not access'))
+    }
+  },
+  authenticate: true
+})
+
+await fastify.register(require('@fastify/swagger-ui', {
+  uiHooks: {
+    onRequest: fastify.basicAuth
+  }
+})
+```
+
 <a name="license"></a>
 ## License
 


### PR DESCRIPTION
When @fastify/swagger-ui was part of @fastify/swagger there used to be documentation for protecting the documentation routes, but that wasn't transferred over when [it was removed](https://github.com/fastify/fastify-swagger/pull/672/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L689) it seems.

I know I've spent a bit of time searching for how to do this, stumbling upon https://github.com/fastify/fastify-swagger/pull/466 and getting confused when the docs are not there anymore in the current HEAD.

I think it would be beneficial to add this to the fastify-swagger-ui docs since it's a very common use case.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
