### PR TITLE
fix(jest): fix a problem with jest and moduleNameMapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const fp = require('fastify-plugin')
 const { readFile } = require('fs/promises')
+const path = require('path')
 
 async function fastifySwaggerUi (fastify, opts) {
   fastify.decorate('swaggerCSP', require('./static/csp.json'))
@@ -12,7 +13,7 @@ async function fastifySwaggerUi (fastify, opts) {
     initOAuth: opts.initOAuth || {},
     hooks: opts.uiHooks,
     theme: opts.theme || {},
-    logo: opts.logo || { type: 'image/svg+xml', content: await readFile(require.resolve('./static/logo.svg')) },
+    logo: opts.logo || { type: 'image/svg+xml', content: await readFile(path.join(__dirname, './static/logo.svg')) },
     ...opts
   })
 }


### PR DESCRIPTION
Jest doesn't support require.resolve method (issue https://github.com/jestjs/jest/issues/9543) and this affected projects if a project has `moduleNameMapper` configuration. I found this issue when I tried to upgrade version of fastify. I changed the implementation on an alternative solution

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
