### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Here is an example using the [`@fastify/basic-auth`](https://github.com/fastify/
 ##### Example
 ```js
 const fastify = require('fastify')()
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 
 fastify.register(require('@fastify/swagger'))
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const { readFile } = require('fs/promises')
-const path = require('path')
+const { readFile } = require('node:fs/promises')
+const path = require('node:path')
 
 async function fastifySwaggerUi (fastify, opts) {
   fastify.decorate('swaggerCSP', require('./static/csp.json'))

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const yaml = require('yaml')
 const fastifyStatic = require('@fastify/static')
 const rfdc = require('rfdc')()

--- a/scripts/prepare-swagger-ui.js
+++ b/scripts/prepare-swagger-ui.js
@@ -1,8 +1,8 @@
-const fs = require('fs')
+const fs = require('node:fs')
 const fse = require('fs-extra')
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 const swaggerUiAssetPath = require('swagger-ui-dist').getAbsoluteFSPath()
-const resolve = require('path').resolve
+const resolve = require('node:path').resolve
 
 const folderName = 'static'
 

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -15,8 +15,8 @@ const {
   swaggerOption
 } = require('../examples/options')
 
-const resolve = require('path').resolve
-const readFileSync = require('fs').readFileSync
+const resolve = require('node:path').resolve
+const readFileSync = require('node:fs').readFileSync
 
 const schemaParamsWithoutDesc = {
   schema: {

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -5,8 +5,8 @@ const Fastify = require('fastify')
 const fastifySwagger = require('@fastify/swagger')
 const fastifySwaggerUi = require('../index')
 const yaml = require('yaml')
-const readFileSync = require('fs').readFileSync
-const resolve = require('path').resolve
+const readFileSync = require('node:fs').readFileSync
+const resolve = require('node:path').resolve
 
 test('swagger route returns yaml', async (t) => {
   const config = {


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
