### PR TITLE
Allow serving static assets from `baseDir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,7 @@ Note that this behavior is disabled by default in `@fastify/swagger-ui`.
 
 ### Bundling
 
-If you want to bundle Swagger UI with your application, you need to copy the swagger-ui static files to your server yourself and set the `baseDir` option to point to your folder.
-
+To bundle Swagger UI with your application, the swagger-ui static files need to be copied to the server and the `baseDir` option set to point to the file directory.
 <details>
 <summary>Copy files with esbuild</summary>
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,51 @@ fastify.register('@fastify/swagger-ui', {
 
 Note that this behavior is disabled by default in `@fastify/swagger-ui`.
 
+### Bundling
+
+If you want to bundle Swagger UI with your application, you need to copy the swagger-ui static files to your server yourself and set the `baseDir` option to point to your folder.
+
+<details>
+<summary>Copy files with esbuild</summary>
+
+```js
+import { build } from 'esbuild'
+import { copy } from 'esbuild-plugin-copy'
+
+await build({
+  // ...
+  plugins: [
+    copy({
+      resolveFrom: 'cwd',
+      assets: {
+        from: ['node_modules/@fastify/swagger-ui/static/*'],
+        to: ['dist/static'],
+      },
+    }),
+  ],
+})
+```
+
+</details>
+
+<details>
+<summary>Copy files with docker</summary>
+
+```Dockerfile
+COPY ./node_modules/@fastify/swagger-ui/static /app/static
+```
+
+</details>
+
+#### Configure Swagger UI to use a custom baseDir
+Set the `baseDir` option to point to your folder.
+
+```js
+await fastify.register(require('@fastify/swagger-ui'), {
+  baseDir: isDev ? undefined : path.resolve('static'),
+})
+```
+
 <a name="license"></a>
 ## License
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -202,7 +202,7 @@ function fastifySwagger (fastify, opts, done) {
 
   // serve swagger-ui with the help of @fastify/static
   fastify.register(fastifyStatic, {
-    root: path.join(__dirname, '..', 'static'),
+    root: opts.baseDir || path.join(__dirname, '..', 'static'),
     prefix: staticPrefix,
     decorateReply: false
   })

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -373,6 +373,33 @@ test('/documentation/static/:file should send back the correct file', async (t) 
   }
 })
 
+test('/documentation/static/:file should send back file from baseDir', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  
+  const uiConfig = {
+    baseDir: resolve(__dirname, '..', 'examples', 'static')
+  }
+
+  await fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwaggerUi, uiConfig)
+
+  {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/documentation/static/example-logo.svg'
+    })
+    t.equal(res.statusCode, 200)
+    t.equal(
+      res.payload,
+      readFileSync(
+        resolve(__dirname, '..', 'examples', 'static', 'example-logo.svg'),
+        'utf8'
+      )
+    )
+  }
+})
+
 test('/documentation/static/:file 404', async (t) => {
   t.plan(2)
   const fastify = Fastify()

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -376,7 +376,7 @@ test('/documentation/static/:file should send back the correct file', async (t) 
 test('/documentation/static/:file should send back file from baseDir', async (t) => {
   t.plan(2)
   const fastify = Fastify()
-  
+
   const uiConfig = {
     baseDir: resolve(__dirname, '..', 'examples', 'static')
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Resolves #65 

This PR documents how to serve static swagger-ui files from a custom directory and fixes serving static assets when the `baseDir` option is set.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
