### PR TITLE
fix: add validatorUrl type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -59,6 +59,13 @@ declare namespace fastifySwaggerUi {
 
     transformSpecification?: (swaggerObject: Readonly<Record<string, any>>, request: FastifyRequest, reply: FastifyReply) => Record<string, any>
     transformSpecificationClone?: boolean
+
+    /**
+     * Use this parameter to set a validator URL
+     * 
+     * @default false
+     */
+    validatorUrl?: string | false
   }
 
   type FastifySwaggerUiTheme = {

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -170,3 +170,11 @@ app.register(fastifySwaggerUi, {
     title: 'My Awesome Swagger Title'
   },
 })
+
+app.register(fastifySwaggerUi, {
+  validatorUrl: false
+})
+
+app.register(fastifySwaggerUi, {
+  validatorUrl: 'https://validator.swagger.io/validator'
+})


### PR DESCRIPTION
Add type for new param 'validatorUrl' in index.d.ts

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
