### PR TITLE
test: deflake tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 'use strict'
 
-const fp = require('fastify-plugin')
-const { readFile } = require('node:fs/promises')
+const fsPromises = require('node:fs/promises')
 const path = require('node:path')
+const fp = require('fastify-plugin')
+const csp = require('./static/csp.json')
 
 async function fastifySwaggerUi (fastify, opts) {
-  fastify.decorate('swaggerCSP', require('./static/csp.json'))
+  const logoContent = await fsPromises.readFile(path.join(__dirname, './static/logo.svg'))
+
+  fastify.decorate('swaggerCSP', csp)
 
   await fastify.register(require('./lib/routes'), {
     prefix: opts.routePrefix || '/documentation',
@@ -13,7 +16,7 @@ async function fastifySwaggerUi (fastify, opts) {
     initOAuth: opts.initOAuth || {},
     hooks: opts.uiHooks,
     theme: opts.theme || {},
-    logo: opts.logo || { type: 'image/svg+xml', content: await readFile(path.join(__dirname, './static/logo.svg')) },
+    logo: opts.logo || { type: 'image/svg+xml', content: logoContent },
     ...opts
   })
 }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -13,7 +13,7 @@ const staticPrefix = '/static'
 function getRedirectPathForTheRootRoute (url) {
   let redirectPath
 
-  if (url.substr(-1) === '/') {
+  if (url.length !== 0 && url[url.length - 1] === '/') {
     redirectPath = `.${staticPrefix}/index.html`
   } else {
     const urlPathParts = url.split('/')
@@ -26,7 +26,7 @@ function getRedirectPathForTheRootRoute (url) {
 function fastifySwagger (fastify, opts, done) {
   let staticCSP = false
   if (opts.staticCSP === true) {
-    const csp = require('../static/csp.json')
+    const csp = fastify.swaggerCSP
     staticCSP = `default-src 'self'; base-uri 'self'; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data: validator.swagger.io; object-src 'none'; script-src 'self' ${csp.script.join(' ')}; script-src-attr 'none'; style-src 'self' https: ${csp.style.join(' ')}; upgrade-insecure-requests;`
   }
   if (typeof opts.staticCSP === 'string') {

--- a/test/decorator.test.js
+++ b/test/decorator.test.js
@@ -6,12 +6,13 @@ const fastifySwagger = require('@fastify/swagger')
 const fastifySwaggerUi = require('../index')
 
 test('fastify.swaggerCSP should exist', async (t) => {
-  t.plan(1)
+  t.plan(3)
   const fastify = Fastify()
 
   await fastify.register(fastifySwagger)
   await fastify.register(fastifySwaggerUi)
 
-  await fastify.ready()
   t.ok(fastify.swaggerCSP)
+  t.ok(Array.isArray(fastify.swaggerCSP.script))
+  t.ok(Array.isArray(fastify.swaggerCSP.style))
 })

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -126,17 +126,15 @@ test('catch all added schema', async t => {
 
   fastify.addSchema({ $id: 'Root', type: 'object', properties: {} })
 
-  fastify.register(function (instance, _, done) {
+  fastify.register(async function (instance) {
     instance.addSchema({ $id: 'Instance', type: 'object', properties: {} })
 
-    instance.register(function (instance, _, done) {
+    await instance.register(async function (instance) {
       instance.addSchema({ $id: 'Sub-Instance', type: 'object', properties: {} })
-      done()
     })
-    done()
   })
 
   await fastify.ready()
-  const openapi = await fastify.swagger()
+  const openapi = fastify.swagger()
   t.same(Object.keys(openapi.components.schemas), ['Root', 'Instance', 'Sub-Instance'])
 })

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -18,15 +18,16 @@ test('fastify will response swagger csp', async (t) => {
 
   await fastify.register(fastifySwagger)
   await fastify.register(fastifySwaggerUi)
-  await fastify.register(fastifyHelmet, instance => {
-    return {
-      contentSecurityPolicy: {
-        directives: {
-          defaultSrc: ["'self'"],
-          imgSrc: ["'self'", 'data:', 'validator.swagger.io'],
-          scriptSrc: ["'self'"].concat(instance.swaggerCSP.script),
-          styleSrc: ["'self'", 'https:'].concat(instance.swaggerCSP.style)
-        }
+
+  const scriptSrc = ["'self'"].concat(fastify.swaggerCSP.script)
+  const styleSrc = ["'self'", 'https:'].concat(fastify.swaggerCSP.style)
+  await fastify.register(fastifyHelmet, {
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        imgSrc: ["'self'", 'data:', 'validator.swagger.io'],
+        scriptSrc,
+        styleSrc
       }
     }
   })

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -18,7 +18,7 @@ test('fastify will response swagger csp', async (t) => {
 
   await fastify.register(fastifySwagger)
   await fastify.register(fastifySwaggerUi)
-  fastify.register(fastifyHelmet, instance => {
+  await fastify.register(fastifyHelmet, instance => {
     return {
       contentSecurityPolicy: {
         directives: {

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -192,7 +192,7 @@ test('/v1/foobar should redirect to ./foobar/static/index.html - in plugin', asy
   t.plan(3)
   const fastify = Fastify()
 
-  await fastify.register(async function (fastify, options) {
+  fastify.register(async function (fastify, options) {
     await fastify.register(fastifySwagger, swaggerOption)
     await fastify.register(fastifySwaggerUi, { routePrefix: '/foobar' })
 
@@ -217,7 +217,7 @@ test('/v1/foobar/ should redirect to ./static/index.html - in plugin', async (t)
   t.plan(3)
   const fastify = Fastify()
 
-  await fastify.register(async function (fastify, options) {
+  fastify.register(async function (fastify, options) {
     await fastify.register(fastifySwagger, swaggerOption)
     await fastify.register(fastifySwaggerUi, { routePrefix: '/foobar' })
 

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -192,7 +192,7 @@ test('/v1/foobar should redirect to ./foobar/static/index.html - in plugin', asy
   t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(async function (fastify, options) {
+  await fastify.register(async function (fastify, options) {
     await fastify.register(fastifySwagger, swaggerOption)
     await fastify.register(fastifySwaggerUi, { routePrefix: '/foobar' })
 
@@ -217,7 +217,7 @@ test('/v1/foobar/ should redirect to ./static/index.html - in plugin', async (t)
   t.plan(3)
   const fastify = Fastify()
 
-  fastify.register(async function (fastify, options) {
+  await fastify.register(async function (fastify, options) {
     await fastify.register(fastifySwagger, swaggerOption)
     await fastify.register(fastifySwaggerUi, { routePrefix: '/foobar' })
 

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1,12 +1,18 @@
 'use strict'
 
+const fs = require('node:fs')
+const resolve = require('node:path').resolve
 const { test } = require('tap')
+const yaml = require('yaml')
 const Fastify = require('fastify')
 const fastifySwagger = require('@fastify/swagger')
 const fastifySwaggerUi = require('../index')
-const yaml = require('yaml')
-const readFileSync = require('node:fs').readFileSync
-const resolve = require('node:path').resolve
+
+const oauthRedirectHtml = fs.readFileSync(resolve(__dirname, '..', 'static', 'oauth2-redirect.html'), 'utf8')
+const exampleStaticSpecificationYaml = fs.readFileSync(
+  resolve(__dirname, '..', 'examples', 'example-static-specification.yaml'),
+  'utf8'
+)
 
 test('swagger route returns yaml', async (t) => {
   t.plan(3)
@@ -157,13 +163,7 @@ test('/documentation/:file should serve static file from the location of main sp
     })
 
     t.equal(res.statusCode, 200)
-    t.equal(
-      readFileSync(
-        resolve(__dirname, '..', 'examples', 'example-static-specification.yaml'),
-        'utf8'
-      ),
-      res.payload
-    )
+    t.equal(exampleStaticSpecificationYaml, res.payload)
   }
 
   {
@@ -225,12 +225,8 @@ test('/documentation/:file should be served from custom location', async (t) => 
     url: '/documentation/oauth2-redirect.html'
   })
 
-  const fileContent = readFileSync(resolve(__dirname, '..', 'static', 'oauth2-redirect.html'), 'utf8')
   t.equal(res.statusCode, 200)
-  t.equal(
-    fileContent,
-    res.payload
-  )
+  t.equal(oauthRedirectHtml, res.payload)
 })
 
 test('/documentation/:file should be served from custom location with trailing slash(es)', async (t) => {
@@ -257,10 +253,7 @@ test('/documentation/:file should be served from custom location with trailing s
   })
 
   t.equal(res.statusCode, 200)
-  t.equal(
-    readFileSync(resolve(__dirname, '..', 'static', 'oauth2-redirect.html'), 'utf8'),
-    res.payload
-  )
+  t.equal(oauthRedirectHtml, res.payload)
 })
 
 test('/documentation/yaml returns cache.swaggerString on second request in static mode', async (t) => {

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -132,7 +132,7 @@ test('/documentation/:file should serve static file from the location of main sp
   }
 
   t.plan(4)
-  const fastify = new Fastify()
+  const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi, uiConfig)
 
@@ -180,7 +180,7 @@ test('/documentation/non-existing-file calls custom NotFoundHandler', async (t) 
   }
 
   t.plan(1)
-  const fastify = new Fastify()
+  const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi)
   fastify.setNotFoundHandler((request, reply) => {
@@ -209,7 +209,7 @@ test('/documentation/:file should be served from custom location', async (t) => 
   }
 
   t.plan(2)
-  const fastify = new Fastify()
+  const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi, uiConfig)
 
@@ -239,7 +239,7 @@ test('/documentation/:file should be served from custom location with trailing s
   }
 
   t.plan(2)
-  const fastify = new Fastify()
+  const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi, uiConfig)
 

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -9,6 +9,8 @@ const readFileSync = require('node:fs').readFileSync
 const resolve = require('node:path').resolve
 
 test('swagger route returns yaml', async (t) => {
+  t.plan(3)
+
   const config = {
     mode: 'static',
     specification: {
@@ -16,7 +18,6 @@ test('swagger route returns yaml', async (t) => {
     }
   }
 
-  t.plan(3)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi)
@@ -34,6 +35,8 @@ test('swagger route returns yaml', async (t) => {
 })
 
 test('swagger route returns json', async (t) => {
+  t.plan(3)
+
   const config = {
     mode: 'static',
     specification: {
@@ -41,7 +44,6 @@ test('swagger route returns json', async (t) => {
     }
   }
 
-  t.plan(3)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi)
@@ -59,6 +61,8 @@ test('swagger route returns json', async (t) => {
 })
 
 test('postProcessor works, swagger route returns updated yaml', async (t) => {
+  t.plan(4)
+
   const config = {
     mode: 'static',
     specification: {
@@ -70,7 +74,6 @@ test('postProcessor works, swagger route returns updated yaml', async (t) => {
     }
   }
 
-  t.plan(4)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi)
@@ -89,6 +92,8 @@ test('postProcessor works, swagger route returns updated yaml', async (t) => {
 })
 
 test('swagger route returns explicitly passed doc', async (t) => {
+  t.plan(2)
+
   const document = {
     info: {
       title: 'Test swagger',
@@ -104,7 +109,6 @@ test('swagger route returns explicitly passed doc', async (t) => {
     }
   }
 
-  t.plan(2)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
 
@@ -120,6 +124,8 @@ test('swagger route returns explicitly passed doc', async (t) => {
 })
 
 test('/documentation/:file should serve static file from the location of main specification file', async (t) => {
+  t.plan(4)
+
   const config = {
     mode: 'static',
     specification: {
@@ -131,7 +137,6 @@ test('/documentation/:file should serve static file from the location of main sp
     baseDir: resolve(__dirname, '..', 'examples')
   }
 
-  t.plan(4)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi, uiConfig)
@@ -172,6 +177,8 @@ test('/documentation/:file should serve static file from the location of main sp
 })
 
 test('/documentation/non-existing-file calls custom NotFoundHandler', async (t) => {
+  t.plan(1)
+
   const config = {
     mode: 'static',
     specification: {
@@ -179,7 +186,6 @@ test('/documentation/non-existing-file calls custom NotFoundHandler', async (t) 
     }
   }
 
-  t.plan(1)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi)
@@ -196,6 +202,8 @@ test('/documentation/non-existing-file calls custom NotFoundHandler', async (t) 
 })
 
 test('/documentation/:file should be served from custom location', async (t) => {
+  t.plan(2)
+
   const config = {
     mode: 'static',
     specification: {
@@ -208,7 +216,6 @@ test('/documentation/:file should be served from custom location', async (t) => 
     baseDir: resolve(__dirname, '..', 'static')
   }
 
-  t.plan(2)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi, uiConfig)
@@ -227,6 +234,8 @@ test('/documentation/:file should be served from custom location', async (t) => 
 })
 
 test('/documentation/:file should be served from custom location with trailing slash(es)', async (t) => {
+  t.plan(2)
+
   const config = {
     mode: 'static',
     specification: {
@@ -238,7 +247,6 @@ test('/documentation/:file should be served from custom location with trailing s
     baseDir: resolve(__dirname, '..', 'static') + '/'
   }
 
-  t.plan(2)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi, uiConfig)
@@ -256,6 +264,8 @@ test('/documentation/:file should be served from custom location with trailing s
 })
 
 test('/documentation/yaml returns cache.swaggerString on second request in static mode', async (t) => {
+  t.plan(6)
+
   const config = {
     mode: 'static',
     specification: {
@@ -263,7 +273,6 @@ test('/documentation/yaml returns cache.swaggerString on second request in stati
     }
   }
 
-  t.plan(6)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi)
@@ -294,6 +303,8 @@ test('/documentation/yaml returns cache.swaggerString on second request in stati
 })
 
 test('/documentation/json returns cache.swaggerObject on second request in static mode', async (t) => {
+  t.plan(6)
+
   const config = {
     mode: 'static',
     specification: {
@@ -301,7 +312,6 @@ test('/documentation/json returns cache.swaggerObject on second request in stati
     }
   }
 
-  t.plan(6)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi)
@@ -330,13 +340,14 @@ test('/documentation/json returns cache.swaggerObject on second request in stati
 })
 
 test('/documentation/yaml returns cache.swaggerString on second request in dynamic mode', async (t) => {
+  t.plan(6)
+
   const config = {
     specification: {
       path: './examples/example-static-specification.yaml'
     }
   }
 
-  t.plan(6)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi)
@@ -367,13 +378,14 @@ test('/documentation/yaml returns cache.swaggerString on second request in dynam
 })
 
 test('/documentation/json returns cache.swaggerObject on second request in dynamic mode', async (t) => {
+  t.plan(6)
+
   const config = {
     specification: {
       path: './examples/example-static-specification.json'
     }
   }
 
-  t.plan(6)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, config)
   await fastify.register(fastifySwaggerUi)

--- a/test/swagger-initializer.test.js
+++ b/test/swagger-initializer.test.js
@@ -8,7 +8,7 @@ const fastifySwaggerUi = require('../index')
 test('/documentation/static/swagger-initializer.js should have default uiConfig', async (t) => {
   t.plan(2)
 
-  const fastify = new Fastify()
+  const fastify = Fastify()
   await fastify.register(fastifySwagger)
   await fastify.register(fastifySwaggerUi)
 
@@ -24,7 +24,7 @@ test('/documentation/static/swagger-initializer.js should have default uiConfig'
 test('/documentation/static/swagger-initializer.js should have configurable uiConfig', async (t) => {
   t.plan(2)
 
-  const fastify = new Fastify()
+  const fastify = Fastify()
   await fastify.register(fastifySwagger)
 
   await fastify.register(fastifySwaggerUi, {
@@ -44,7 +44,7 @@ test('/documentation/static/swagger-initializer.js should have configurable uiCo
 test('/documentation/static/swagger-initializer.js should have default initOAuth', async (t) => {
   t.plan(2)
 
-  const fastify = new Fastify()
+  const fastify = Fastify()
   await fastify.register(fastifySwagger)
   await fastify.register(fastifySwaggerUi)
 
@@ -60,7 +60,7 @@ test('/documentation/static/swagger-initializer.js should have default initOAuth
 test('/documentation/static/swagger-initializer.js should have configurable initOAuth', async (t) => {
   t.plan(2)
 
-  const fastify = new Fastify()
+  const fastify = Fastify()
   await fastify.register(fastifySwagger)
   await fastify.register(fastifySwaggerUi, {
     initOAuth: {


### PR DESCRIPTION
Closes #110 
I guess we should have awaited some of the .register() calls and make it more robust.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
