### PR TITLE
perf: Reduce package size by removing sourceMaps

### DIFF
--- a/scripts/prepare-swagger-ui.js
+++ b/scripts/prepare-swagger-ui.js
@@ -16,16 +16,21 @@ const filesToCopy = [
   'index.css',
   'oauth2-redirect.html',
   'swagger-ui-bundle.js',
-  'swagger-ui-bundle.js.map',
   'swagger-ui-standalone-preset.js',
-  'swagger-ui-standalone-preset.js.map',
   'swagger-ui.css',
-  'swagger-ui.css.map',
-  'swagger-ui.js',
-  'swagger-ui.js.map'
+  'swagger-ui.js'
 ]
 filesToCopy.forEach(filename => {
-  fse.copySync(`${swaggerUiAssetPath}/${filename}`, resolve(`./static/${filename}`))
+  fse.ensureFileSync(resolve(`./static/${filename}`))
+  const readableStream = fs.createReadStream(`${swaggerUiAssetPath}/${filename}`, 'utf8')
+  const writableStream = fs.createWriteStream(resolve(`./static/${filename}`))
+  // Matches sourceMappingURL comments in .js and .css files
+  const sourceMapRegex = new RegExp(String.raw`\/.# sourceMappingURL=${filename}.map(\*\/)?$`)
+
+  readableStream.on('data', (chunk) => {
+    // Copy file while removing sourceMappingURL comments
+    writableStream.write(chunk.replace(sourceMapRegex, ''))
+  })
 })
 
 const overrides = [

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const fastifySwagger = require('@fastify/swagger')
+const fastifySwaggerUi = require('../index')
+
+test('Swagger source does not contain sourceMaps', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  await fastify.register(fastifySwagger)
+  await fastify.register(fastifySwaggerUi)
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/documentation/static/swagger-ui.js'
+  })
+
+  const includesSourceMap = res.payload.includes('sourceMappingURL')
+  t.equal(includesSourceMap, false)
+  t.equal(res.headers['content-type'], 'application/javascript; charset=UTF-8')
+})
+
+test('Swagger css does not contain sourceMaps', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  await fastify.register(fastifySwagger)
+  await fastify.register(fastifySwaggerUi)
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/documentation/static/swagger-ui.css'
+  })
+
+  const includesSourceMap = res.payload.includes('sourceMappingURL')
+  t.equal(includesSourceMap, false)
+  t.equal(res.headers['content-type'], 'text/css; charset=UTF-8')
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Description

Closes #121 

By removing sourceMaps, the size of `@fastify/swagger-ui` package is reduced by **`~2.7MB`**.

This PR modifies `prepare-swagger-ui.js` to not bundle `.map` files, but also removes the source map annotation from the source files so browsers do not attempt to retrieve the sourceMaps.

Please see the [Source Map SPEC](https://sourcemaps.info/spec.html#h.lmz475t4mvbx) for the definition of the sourceMap annotations we are removing. 

The annotation comments are slightly different for js/css, and I'm using a regex to handle both cases
- **Js:** `//# sourceMappingURL=swagger-ui.js.map`
- **css:** `/*# sourceMappingURL=swagger-ui.css.map*/`


![image](https://github.com/fastify/fastify-swagger-ui/assets/2258445/29e60ddf-59cc-4070-90e2-47a63dbbc780)

#### Build performance

I was worried searching/removing the annotations from the source files would be quite slow but there does not seem to be a performance impact.

##### Before
<img width="436" alt="image" src="https://github.com/fastify/fastify-swagger-ui/assets/2258445/ec7da739-c355-4f88-a4cc-b83226fd1a86">
<img width="382" alt="image" src="https://github.com/fastify/fastify-swagger-ui/assets/2258445/ab0e1b7c-5fbe-47a6-b565-383435225472">


##### After
<img width="478" alt="image" src="https://github.com/fastify/fastify-swagger-ui/assets/2258445/6c30258d-fa7e-4747-acde-c0bec51c2d89">
<img width="448" alt="image" src="https://github.com/fastify/fastify-swagger-ui/assets/2258445/03f5e626-aaa0-4edc-9af6-3f22c172e6bd">



#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
