### PR TITLE
Serve UI directly at the route prefix, rather than redirecting

### DIFF
--- a/e2e/custom.test.js
+++ b/e2e/custom.test.js
@@ -45,3 +45,37 @@ test.describe('Check customizations', () => {
     expect(logoId).toBe('example-logo') // it is included in the svg file
   })
 })
+
+test.describe('Check redirection and url handling of static assets', () => {
+  test('Check static/index.html redirects', async ({ page }) => {
+    const jsonResponsePromise = page.waitForResponse(/json/)
+    await page.goto(`${URL_DOCUMENTATION}/static/index.html`)
+
+    // Check if the page is redirected to /documentation
+    const url = await page.url()
+    expect(url).toContain(`${URL_DOCUMENTATION}`)
+    expect(url).not.toContain('static/index.html')
+
+    // Check if the page has requested the json spec, and if so has it succeeded
+    const jsonResponse = await jsonResponsePromise
+    expect(jsonResponse.ok()).toBe(true)
+  })
+
+  test('Check root UI without slash loads json spec', async ({ page }) => {
+    const jsonResponsePromise = page.waitForResponse(/json/)
+    await page.goto(`${URL_DOCUMENTATION}`)
+
+    // Check if the page has requested the json spec, and if so has it succeeded
+    const jsonResponse = await jsonResponsePromise
+    expect(jsonResponse.ok()).toBe(true)
+  })
+
+  test('Check root UI with trailing slash loads json spec', async ({ page }) => {
+    const jsonResponsePromise = page.waitForResponse(/json/)
+    await page.goto(`${URL_DOCUMENTATION}/`)
+
+    // Check if the page has requested the json spec, and if so has it succeeded
+    const jsonResponse = await jsonResponsePromise
+    expect(jsonResponse.ok()).toBe(true)
+  })
+})

--- a/lib/index-html.js
+++ b/lib/index-html.js
@@ -1,29 +1,29 @@
 'use strict'
 
 function indexHtml (opts) {
-  return `<!-- HTML for static distribution bundle build -->
+  return (url) => `<!-- HTML for static distribution bundle build -->
   <!DOCTYPE html>
   <html lang="en">
   <head>
   <meta charset="UTF-8">
   <title>${opts.theme?.title || 'Swagger UI'}</title>
-  <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
-  <link rel="stylesheet" type="text/css" href="./index.css" />
-  ${opts.theme && opts.theme.css ? opts.theme.css.map(css => `<link rel="stylesheet" type="text/css" href="./theme/${css.filename}" />\n`).join('') : ''}
+  <link rel="stylesheet" type="text/css" href="${url}${opts.staticPrefix}/swagger-ui.css" />
+  <link rel="stylesheet" type="text/css" href="${url}${opts.staticPrefix}/index.css" />
+  ${opts.theme && opts.theme.css ? opts.theme.css.map(css => `<link rel="stylesheet" type="text/css" href="${url}${opts.staticPrefix}/theme/${css.filename}" />\n`).join('') : ''}
   ${opts.theme && opts.theme.favicon
-? opts.theme.favicon.map(favicon => `<link rel="${favicon.rel}" type="${favicon.type}" href="./theme/${favicon.filename}" sizes="${favicon.sizes}" />\n`).join('')
+? opts.theme.favicon.map(favicon => `<link rel="${favicon.rel}" type="${favicon.type}" href="${url}${opts.staticPrefix}/theme/${favicon.filename}" sizes="${favicon.sizes}" />\n`).join('')
 : `
-  <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+  <link rel="icon" type="image/png" href="${url}${opts.staticPrefix}/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="${url}${opts.staticPrefix}/favicon-16x16.png" sizes="16x16" />
   `}
   </head>
   
   <body>
   <div id="swagger-ui"></div>
-  <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
-  <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
-  <script src="./swagger-initializer.js" charset="UTF-8"> </script>
-  ${opts.theme && opts.theme.js ? opts.theme.js.map(js => `<script src="./theme/${js.filename}" charset="UTF-8"> </script>\n`).join('') : ''}
+  <script src="${url}${opts.staticPrefix}/swagger-ui-bundle.js" charset="UTF-8"> </script>
+  <script src="${url}${opts.staticPrefix}/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+  <script src="${url}${opts.staticPrefix}/swagger-initializer.js" charset="UTF-8"> </script>
+  ${opts.theme && opts.theme.js ? opts.theme.js.map(js => `<script src="${url}${opts.staticPrefix}/theme/${js.filename}" charset="UTF-8"> </script>\n`).join('') : ''}
   </body>
   </html>
   `

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -10,19 +10,6 @@ const indexHtml = require('./index-html')
 // URI prefix to separate static assets for swagger UI
 const staticPrefix = '/static'
 
-function getRedirectPathForTheRootRoute (url) {
-  let redirectPath
-
-  if (url.length !== 0 && url[url.length - 1] === '/') {
-    redirectPath = `.${staticPrefix}/index.html`
-  } else {
-    const urlPathParts = url.split('/')
-    redirectPath = `./${urlPathParts[urlPathParts.length - 1]}${staticPrefix}/index.html`
-  }
-
-  return redirectPath
-}
-
 function fastifySwagger (fastify, opts, done) {
   let staticCSP = false
   if (opts.staticCSP === true) {
@@ -65,16 +52,6 @@ function fastifySwagger (fastify, opts, done) {
       hooks[hook] = opts.hooks[hook]
     }
   }
-
-  fastify.route({
-    url: '/',
-    method: 'GET',
-    schema: { hide: true },
-    ...hooks,
-    handler: (req, reply) => {
-      reply.redirect(getRedirectPathForTheRootRoute(req.raw.url))
-    }
-  })
 
   if (opts.theme) {
     const themePrefix = `${staticPrefix}/theme`
@@ -127,7 +104,19 @@ function fastifySwagger (fastify, opts, done) {
     }
   }
 
-  const indexHtmlContent = indexHtml(opts)
+  const indexHtmlContent = indexHtml({ ...opts, staticPrefix })
+
+  fastify.route({
+    url: '/',
+    method: 'GET',
+    schema: { hide: true },
+    ...hooks,
+    handler: (req, reply) => {
+      reply
+        .header('content-type', 'text/html; charset=utf-8')
+        .send(indexHtmlContent(req.url.replace(/\/$/, ''))) // remove trailing slash, as staticPrefix has a leading slash
+    }
+  })
 
   fastify.route({
     url: `${staticPrefix}/index.html`,
@@ -135,9 +124,7 @@ function fastifySwagger (fastify, opts, done) {
     schema: { hide: true },
     ...hooks,
     handler: (req, reply) => {
-      reply
-        .header('content-type', 'text/html; charset=utf-8')
-        .send(indexHtmlContent)
+      reply.redirect(req.url.replace(/\/static\/index\.html$/, '/'))
     }
   })
 

--- a/lib/swagger-initializer.js
+++ b/lib/swagger-initializer.js
@@ -28,8 +28,10 @@ function swaggerInitializer (opts) {
       });
     }
     function resolveUrl(url) {
-      const anchor = document.createElement('a')
-      anchor.href = url
+      var currentHref = window.location.href;
+      currentHref = currentHref.endsWith('/') ? currentHref : currentHref + '/';
+      var anchor = document.createElement('a');
+      anchor.href = currentHref + url;
       return anchor.href
     }
 
@@ -47,8 +49,8 @@ function swaggerInitializer (opts) {
       layout: "StandaloneLayout",
       validatorUrl: ${serialize(opts.validatorUrl || null)},
     }, config, {
-      url: resolveUrl('./json').replace('static/json', 'json'),
-      oauth2RedirectUrl: resolveUrl('./oauth2-redirect.html')
+      url: resolveUrl('./json'),
+      oauth2RedirectUrl: resolveUrl('./static/oauth2-redirect.html')
     });
 
     const ui = SwaggerUIBundle(resConfig)

--- a/test/csp.test.js
+++ b/test/csp.test.js
@@ -31,7 +31,7 @@ test('staticCSP = undefined', async (t) => {
 
   const res = await fastify.inject({
     method: 'GET',
-    url: '/documentation/static/index.html'
+    url: '/documentation'
   })
   t.equal(res.statusCode, 200)
   t.equal(typeof res.headers['content-security-policy'], 'undefined')
@@ -57,7 +57,7 @@ test('staticCSP = true', async (t) => {
   {
     const res = await fastify.inject({
       method: 'GET',
-      url: '/documentation/static/index.html'
+      url: '/documentation'
     })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], `default-src 'self'; base-uri 'self'; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data: validator.swagger.io; object-src 'none'; script-src 'self' ${csp.script.join(' ')}; script-src-attr 'none'; style-src 'self' https: ${csp.style.join(' ')}; upgrade-insecure-requests;`)
@@ -93,7 +93,7 @@ test('staticCSP = "default-src \'self\';"', async (t) => {
   {
     const res = await fastify.inject({
       method: 'GET',
-      url: '/documentation/static/index.html'
+      url: '/documentation'
     })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], "default-src 'self';")
@@ -132,7 +132,7 @@ test('staticCSP = object', async (t) => {
   {
     const res = await fastify.inject({
       method: 'GET',
-      url: '/documentation/static/index.html'
+      url: '/documentation'
     })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], "default-src 'self'; script-src 'self';")
@@ -172,7 +172,7 @@ test('transformStaticCSP = function', async (t) => {
   {
     const res = await fastify.inject({
       method: 'GET',
-      url: '/documentation/static/index.html'
+      url: '/documentation'
     })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], "default-src 'self'; script-src 'self';")
@@ -212,7 +212,7 @@ test('transformStaticCSP = function, with @fastify/helmet', async (t) => {
   {
     const res = await fastify.inject({
       method: 'GET',
-      url: '/documentation/static/index.html'
+      url: '/documentation'
     })
     t.equal(res.statusCode, 200)
     t.equal(res.headers['content-security-policy'], "default-src 'self'; script-src 'self';")

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -100,8 +100,8 @@ test('fastify.swagger should return a valid swagger yaml', async (t) => {
   t.pass('valid swagger yaml')
 })
 
-test('/documentation should redirect to ./documentation/static/index.html', async (t) => {
-  t.plan(3)
+test('/documentation should display index html', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, swaggerOption)
   await fastify.register(fastifySwaggerUi)
@@ -117,13 +117,14 @@ test('/documentation should redirect to ./documentation/static/index.html', asyn
     method: 'GET',
     url: '/documentation'
   })
-  t.equal(res.statusCode, 302)
-  t.equal(res.headers.location, './documentation/static/index.html')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers.location, undefined)
   t.equal(typeof res.payload, 'string')
+  t.equal('text/html; charset=utf-8', res.headers['content-type'])
 })
 
-test('/documentation/ should redirect to ./static/index.html', async (t) => {
-  t.plan(3)
+test('/documentation/ should display index html ', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, swaggerOption)
   await fastify.register(fastifySwaggerUi)
@@ -139,13 +140,14 @@ test('/documentation/ should redirect to ./static/index.html', async (t) => {
     method: 'GET',
     url: '/documentation/'
   })
-  t.equal(res.statusCode, 302)
-  t.equal(res.headers.location, './static/index.html')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers.location, undefined)
   t.equal(typeof res.payload, 'string')
+  t.equal('text/html; charset=utf-8', res.headers['content-type'])
 })
 
-test('/v1/documentation should redirect to ./documentation/static/index.html', async (t) => {
-  t.plan(3)
+test('/v1/documentation should display index html', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, swaggerOption)
   await fastify.register(fastifySwaggerUi, { routePrefix: '/v1/documentation' })
@@ -161,13 +163,14 @@ test('/v1/documentation should redirect to ./documentation/static/index.html', a
     method: 'GET',
     url: '/v1/documentation'
   })
-  t.equal(res.statusCode, 302)
-  t.equal(res.headers.location, './documentation/static/index.html')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers.location, undefined)
   t.equal(typeof res.payload, 'string')
+  t.equal('text/html; charset=utf-8', res.headers['content-type'])
 })
 
-test('/v1/documentation/ should redirect to ./static/index.html', async (t) => {
-  t.plan(3)
+test('/v1/documentation/ should display index html', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
   await fastify.register(fastifySwagger, swaggerOption)
   await fastify.register(fastifySwaggerUi, { routePrefix: '/v1/documentation' })
@@ -183,18 +186,19 @@ test('/v1/documentation/ should redirect to ./static/index.html', async (t) => {
     method: 'GET',
     url: '/v1/documentation/'
   })
-  t.equal(res.statusCode, 302)
-  t.equal(res.headers.location, './static/index.html')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers.location, undefined)
   t.equal(typeof res.payload, 'string')
+  t.equal('text/html; charset=utf-8', res.headers['content-type'])
 })
 
-test('/v1/foobar should redirect to ./foobar/static/index.html - in plugin', async (t) => {
-  t.plan(3)
+test('/v1/foobar should display index html', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
 
   fastify.register(async function (fastify, options) {
     await fastify.register(fastifySwagger, swaggerOption)
-    await fastify.register(fastifySwaggerUi, { routePrefix: '/foobar' })
+    await fastify.register(fastifySwaggerUi, { routePrefix: '/foobar', noRedirect: true })
 
     fastify.get('/', () => {})
     fastify.post('/', () => {})
@@ -208,13 +212,14 @@ test('/v1/foobar should redirect to ./foobar/static/index.html - in plugin', asy
     method: 'GET',
     url: '/v1/foobar'
   })
-  t.equal(res.statusCode, 302)
-  t.equal(res.headers.location, './foobar/static/index.html')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers.location, undefined)
   t.equal(typeof res.payload, 'string')
+  t.equal('text/html; charset=utf-8', res.headers['content-type'])
 })
 
-test('/v1/foobar/ should redirect to ./static/index.html - in plugin', async (t) => {
-  t.plan(3)
+test('/v1/foobar/ should display index html', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
 
   fastify.register(async function (fastify, options) {
@@ -233,13 +238,14 @@ test('/v1/foobar/ should redirect to ./static/index.html - in plugin', async (t)
     method: 'GET',
     url: '/v1/foobar/'
   })
-  t.equal(res.statusCode, 302)
-  t.equal(res.headers.location, './static/index.html')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers.location, undefined)
   t.equal(typeof res.payload, 'string')
+  t.equal('text/html; charset=utf-8', res.headers['content-type'])
 })
 
-test('with routePrefix: \'/\' should redirect to ./static/index.html', async (t) => {
-  t.plan(3)
+test('with routePrefix: \'/\' should display index html', async (t) => {
+  t.plan(4)
   const fastify = Fastify()
 
   await fastify.register(fastifySwagger, swaggerOption)
@@ -251,9 +257,10 @@ test('with routePrefix: \'/\' should redirect to ./static/index.html', async (t)
     method: 'GET',
     url: '/'
   })
-  t.equal(res.statusCode, 302)
-  t.equal(res.headers.location, './static/index.html')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers.location, undefined)
   t.equal(typeof res.payload, 'string')
+  t.equal('text/html; charset=utf-8', res.headers['content-type'])
 })
 
 test('/documentation/static/:file should send back the correct file', async (t) => {
@@ -275,10 +282,10 @@ test('/documentation/static/:file should send back the correct file', async (t) 
   {
     const res = await fastify.inject({
       method: 'GET',
-      url: '/documentation/'
+      url: '/documentation/static/index.html'
     })
     t.equal(res.statusCode, 302)
-    t.equal(res.headers.location, './static/index.html')
+    t.equal(res.headers.location, '/documentation/')
   }
 
   {
@@ -481,20 +488,6 @@ test('/documentation/:myfile should run custom NotFoundHandler in dynamic mode',
   t.equal(res.statusCode, 410)
 })
 
-test('/documentation/ should redirect to ./static/index.html', async (t) => {
-  t.plan(2)
-  const fastify = Fastify()
-  await fastify.register(fastifySwagger, swaggerOption)
-  await fastify.register(fastifySwaggerUi)
-
-  const res = await fastify.inject({
-    method: 'GET',
-    url: '/documentation/'
-  })
-  t.equal(res.statusCode, 302)
-  t.equal(res.headers.location, './static/index.html')
-})
-
 test('/documentation/* should not return module files when baseDir not set', async (t) => {
   t.plan(1)
   const fastify = Fastify()
@@ -522,8 +515,8 @@ test('should return silent log level of route /documentation', async (t) => {
     method: 'GET',
     url: '/documentation/'
   })
-  t.equal(res.statusCode, 302)
-  t.equal(res.headers.location, './static/index.html')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['content-type'], 'text/html; charset=utf-8')
 })
 
 test('should return empty log level of route /documentation', async (t) => {
@@ -540,6 +533,23 @@ test('should return empty log level of route /documentation', async (t) => {
     method: 'GET',
     url: '/documentation/'
   })
-  t.equal(res.statusCode, 302)
-  t.equal(res.headers.location, './static/index.html')
+  t.equal(res.statusCode, 200)
+  t.equal(res.headers['content-type'], 'text/html; charset=utf-8')
+})
+
+test('/documentation should display index html with correct asset urls', async (t) => {
+  t.plan(4)
+  const fastify = Fastify()
+  await fastify.register(fastifySwagger, swaggerOption)
+  await fastify.register(fastifySwaggerUi, { theme: { js: [{ filename: 'theme-js.js' }] } })
+
+  const res = await fastify.inject({
+    method: 'GET',
+    url: '/documentation'
+  })
+
+  t.equal(res.payload.includes('href="/documentation/static/index.css"'), true)
+  t.equal(res.payload.includes('src="/documentation/static/theme/theme-js.js"'), true)
+  t.equal(res.payload.includes('href="/documentation/index.css"'), false)
+  t.equal(res.payload.includes('src="/documentation/theme/theme-js.js"'), false)
 })

--- a/test/theme.test.js
+++ b/test/theme.test.js
@@ -20,7 +20,7 @@ test('swagger route does not return additional theme', async (t) => {
 
   const res = await fastify.inject({
     method: 'GET',
-    url: '/documentation/static/index.html'
+    url: '/documentation'
   })
 
   t.equal(typeof res.payload, 'string')
@@ -63,7 +63,7 @@ test('swagger route returns additional theme', async (t) => {
 
   const res = await fastify.inject({
     method: 'GET',
-    url: '/documentation/static/index.html'
+    url: '/documentation'
   })
 
   t.equal(typeof res.payload, 'string')
@@ -119,7 +119,7 @@ test('swagger route returns additional theme - only js', async (t) => {
 
   const res = await fastify.inject({
     method: 'GET',
-    url: '/documentation/static/index.html'
+    url: '/documentation'
   })
 
   t.equal(typeof res.payload, 'string')
@@ -156,7 +156,7 @@ test('swagger route returns additional theme - only css', async (t) => {
 
   const res = await fastify.inject({
     method: 'GET',
-    url: '/documentation/static/index.html'
+    url: '/documentation'
   })
 
   t.equal(typeof res.payload, 'string')
@@ -199,7 +199,7 @@ test('swagger route returns additional theme - only favicon', async (t) => {
 
   const res = await fastify.inject({
     method: 'GET',
-    url: '/documentation/static/index.html'
+    url: '/documentation'
   })
 
   t.equal(typeof res.payload, 'string')
@@ -235,7 +235,7 @@ test('swagger route returns additional theme - only title', async (t) => {
 
   const res = await fastify.inject({
     method: 'GET',
-    url: '/documentation/static/index.html'
+    url: '/documentation'
   })
 
   t.equal(typeof res.payload, 'string')


### PR DESCRIPTION
This PR is related to #117. I like the suggestion, and it would be beneficial to me to have this feature, so I've implemented it.

Previously, when visiting the swagger UI route (default `/documentation`), the page redirected to `/documentation/static/index.html` to display the UI. This no longer is the case, rather the UI is served directly.

This should not affect any existing links to `/documentation/static/index.html` as they will be redirected to `/documentation` and function as before.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and ~`npm run benchmark`~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)