### PR TITLE
fix: hash loads json spec

### DIFF
--- a/e2e/custom.test.js
+++ b/e2e/custom.test.js
@@ -78,4 +78,13 @@ test.describe('Check redirection and url handling of static assets', () => {
     const jsonResponse = await jsonResponsePromise
     expect(jsonResponse.ok()).toBe(true)
   })
+
+  test('Check root UI with hash loads json spec', async ({ page }) => {
+    const jsonResponsePromise = page.waitForResponse(/json/)
+    await page.goto(`${URL_DOCUMENTATION}#default/get_example`)
+
+    // Check if the page has requested the json spec, and if so has it succeeded
+    const jsonResponse = await jsonResponsePromise
+    expect(jsonResponse.ok()).toBe(true)
+  })
 })

--- a/lib/swagger-initializer.js
+++ b/lib/swagger-initializer.js
@@ -29,7 +29,7 @@ function swaggerInitializer (opts) {
     }
     function resolveUrl(url) {
       var currentHref = window.location.href;
-      currentHref = currentHref.split('#')[0];
+      currentHref = currentHref.split('#', 1)[0];
       currentHref = currentHref.endsWith('/') ? currentHref : currentHref + '/';
       var anchor = document.createElement('a');
       anchor.href = currentHref + url;

--- a/lib/swagger-initializer.js
+++ b/lib/swagger-initializer.js
@@ -29,6 +29,7 @@ function swaggerInitializer (opts) {
     }
     function resolveUrl(url) {
       var currentHref = window.location.href;
+      currentHref = currentHref.split('#')[0];
       currentHref = currentHref.endsWith('/') ? currentHref : currentHref + '/';
       var anchor = document.createElement('a');
       anchor.href = currentHref + url;


### PR DESCRIPTION
## Summary
Fix json specs route issues when url contains `#` #158 

## Test Plan
### Command
```sh
npm install
npx playwright install
npm run test:e2e
```
### Result
```sh
> @fastify/swagger-ui@5.0.0-pre.fv5.1 test:e2e
> npx playwright test


Running 8 tests using 4 workers
  8 passed (12.2s
```

### Result wihout new test
```sh
> @fastify/swagger-ui@5.0.0-pre.fv5.1 test:e2e
> npx playwright test


Running 8 tests using 4 workers
  1) [chromium] › custom.test.js:82:3 › Check redirection and url handling of static assets › Check root UI with hash loads json spec 

    Test timeout of 30000ms exceeded.

    Error: page.waitForResponse: Test timeout of 30000ms exceeded.
    =========================== logs ===========================
    waiting for response /json/
    ============================================================

      81 |
      82 |   test('Check root UI with hash loads json spec', async ({ page }) => {
    > 83 |     const jsonResponsePromise = page.waitForResponse(/json/)
         |                                      ^
      84 |     await page.goto(`${URL_DOCUMENTATION}#default/get_example`)
      85 |
      86 |     // Check if the page has requested the json spec, and if so has it succeeded

        at .../fastify-swagger-ui/e2e/custom.test.js:83:38

  1 failed
    [chromium] › custom.test.js:82:3 › Check redirection and url handling of static assets › Check root UI with hash loads json spec 
  7 passed (33.8s)
```

#### Checklist

- [x] run `npm run test` and ~`npm run benchmark`~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
