### PR TITLE
fix: static content for routePrefix with subpath (#165)

### DIFF
--- a/lib/index-html.js
+++ b/lib/index-html.js
@@ -2,7 +2,7 @@
 
 function indexHtml (opts) {
   return (hasTrailingSlash) => {
-    const prefix = hasTrailingSlash ? `.${opts.staticPrefix}` : `.${opts.prefix}${opts.staticPrefix}`
+    const prefix = hasTrailingSlash ? `.${opts.staticPrefix}` : `${opts.prefix}${opts.staticPrefix}`
     return `<!-- HTML for static distribution bundle build -->
       <!DOCTYPE html>
       <html lang="en">

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -548,10 +548,10 @@ test('/documentation should display index html with correct asset urls', async (
     url: '/documentation'
   })
 
-  t.equal(res.payload.includes('href="./documentation/static/index.css"'), true)
-  t.equal(res.payload.includes('src="./documentation/static/theme/theme-js.js"'), true)
-  t.equal(res.payload.includes('href="./documentation/index.css"'), false)
-  t.equal(res.payload.includes('src="./documentation/theme/theme-js.js"'), false)
+  t.equal(res.payload.includes('href="/documentation/static/index.css"'), true)
+  t.equal(res.payload.includes('src="/documentation/static/theme/theme-js.js"'), true)
+  t.equal(res.payload.includes('href="/documentation/index.css"'), false)
+  t.equal(res.payload.includes('src="/documentation/theme/theme-js.js"'), false)
 })
 
 test('/documentation/ should display index html with correct asset urls', async (t) => {
@@ -582,10 +582,10 @@ test('/docs should display index html with correct asset urls when documentation
     url: '/docs'
   })
 
-  t.equal(res.payload.includes('href="./docs/static/index.css"'), true)
-  t.equal(res.payload.includes('src="./docs/static/theme/theme-js.js"'), true)
-  t.equal(res.payload.includes('href="./docs/index.css"'), false)
-  t.equal(res.payload.includes('src="./docs/theme/theme-js.js"'), false)
+  t.equal(res.payload.includes('href="/docs/static/index.css"'), true)
+  t.equal(res.payload.includes('src="/docs/static/theme/theme-js.js"'), true)
+  t.equal(res.payload.includes('href="/docs/index.css"'), false)
+  t.equal(res.payload.includes('src="/docs/theme/theme-js.js"'), false)
 })
 
 test('/docs/ should display index html with correct asset urls when documentation prefix is set', async (t) => {


### PR DESCRIPTION
This fixes https://github.com/fastify/fastify-swagger-ui/issues/165, where having a subpath in `routePrefix` breaks static content loading due to changes in https://github.com/fastify/fastify-swagger-ui/pull/164.

Now the static content urls are relative only with a trailing slash, otherwise they're absolute - meaning they work the same as before the regression.

The tests for this were already developed but with wrong assertions, to be able to test static content is loaded I assume we'd need to run playwright with different prefix variations, which would require a refactor as all playwright tests are run with `/documentation` as the prefix.  
Please let me know if you have any suggestions regarding the tests.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
