### PR TITLE
[backbport v4.x] fix: html urls should not be absolute 

### DIFF
--- a/lib/index-html.js
+++ b/lib/index-html.js
@@ -1,8 +1,10 @@
 'use strict'
 
 function indexHtml (opts) {
-  return (hasTrailingSlash) => {
-    const prefix = hasTrailingSlash ? `.${opts.staticPrefix}` : `${opts.prefix}${opts.staticPrefix}`
+  const hasLeadingSlash = /^\//.test(opts.prefix)
+  return (url) => {
+    const hasTrailingSlash = /\/$/.test(url)
+    const prefix = hasTrailingSlash ? `.${opts.staticPrefix}` : `${hasLeadingSlash ? '.' : ''}${opts.prefix}${opts.staticPrefix}`
     return `<!-- HTML for static distribution bundle build -->
       <!DOCTYPE html>
       <html lang="en">

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -112,10 +112,9 @@ function fastifySwagger (fastify, opts, done) {
     schema: { hide: true },
     ...hooks,
     handler: (req, reply) => {
-      const hasTrailingSlash = /\/$/.test(req.url)
       reply
         .header('content-type', 'text/html; charset=utf-8')
-        .send(indexHtmlContent(hasTrailingSlash)) // trailing slash alters the relative urls generated in the html
+        .send(indexHtmlContent(req.url)) // trailing slash alters the relative urls generated in the html
     }
   })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [N/A] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

When the HTML uses an absolute URL, `/documentation/index.css`, then the browser requests the data from the `/`.  This is an issue if swagger is set up as a nested route.  I added a test for this where swagger is registered as a child of another prefix route.

Fixed #176 

Related to #164, #162
