### PR TITLE
ci: set permissions at workflow level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ on:
       - 'docs/**'
       - '*.md'
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     uses: ./.github/workflows/playwright.yml
 
   test:
-    permissions:
-      contents: write
-      pull-requests: write
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v5
     needs: e2e
     with:


### PR DESCRIPTION
This is a batch PR. This change stops security tools like step-security from complaining.