### PR TITLE
ci: remove tests_checker workflow

### DIFF
--- a/.github/tests_checker.yml
+++ b/.github/tests_checker.yml
@@ -1,8 +1,0 @@
-comment: |
-  Hello! Thank you for contributing!
-  It appears that you have changed the code, but the tests that verify your change are missing. Could you please add them?
-fileExtensions:
-  - '.ts'
-  - '.js'
-
-testDir: 'test'


### PR DESCRIPTION
Proposal:

Removed `tests_checker.yml` workflow configuration file. The tests-checker ( Bot ) action has been deprecated by the maintainers (see here: https://github.com/infection/tests-checker)

It is not actually used during the CI (continuous integration) flow.