### PR TITLE
chore(types): remove useUnsafeMarkdown parameter deprecated

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -299,14 +299,6 @@ declare namespace fastifySwaggerUi {
     tagsSorter?: SorterLike | undefined;
 
     /**
-     * When enabled, sanitizer will leave style, class and data-* attributes untouched
-     * on all HTML Elements declared inside markdown strings.
-     * This parameter is Deprecated and will be removed in 4.0.0.
-     * @deprecated
-     */
-    useUnsafeMarkdown?: boolean | undefined;
-
-    /**
      * Provides a mechanism to be notified when Swagger UI has finished rendering a newly provided definition.
      */
     onComplete?: (() => any) | undefined;


### PR DESCRIPTION
Proposal:

- Removes the `useUnsafeMarkdown` option from the `FastifySwaggerUiConfigOptions` namespace type definitions.
This property was already marked as `@deprecated` and scheduled for removal in v4.0.0. Since we are now at v5.2.6, it is safe to drop it entirely from the types to keep them in sync with the actual runtime behavior.

Note:

- Release a major version of the plugin after this pull request has been merged
