### PR TITLE
test: fix CSP header order assertion for helmet@8.3.x

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -10,9 +10,11 @@ const swaggerCSP = require('../static/csp.json')
 test('fastify will response swagger csp', async (t) => {
   t.plan(1)
 
-  const scriptCSP = swaggerCSP.script.length > 0 ? ` ${swaggerCSP.script.join(' ')}` : ''
-  const styleCSP = swaggerCSP.style.length > 0 ? ` ${swaggerCSP.style.join(' ')}` : ''
-  const csp = `default-src 'self';img-src 'self' data: validator.swagger.io;script-src 'self'${scriptCSP};style-src 'self' https:${styleCSP};base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';upgrade-insecure-requests`
+  const scriptCSP =
+    swaggerCSP.script.length > 0 ? ` ${swaggerCSP.script.join(' ')}` : ''
+  const styleCSP =
+    swaggerCSP.style.length > 0 ? ` ${swaggerCSP.style.join(' ')}` : ''
+  const csp = `default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data: validator.swagger.io;object-src 'none';script-src 'self'${scriptCSP};script-src-attr 'none';style-src 'self' https:${styleCSP};upgrade-insecure-requests`
 
   const fastify = Fastify()
 


### PR DESCRIPTION
Proposal:

- Fixes a failing CI test in `test/integration.test.js` ( see here: https://github.com/fastify/fastify-swagger-ui/actions/runs/29720059866/job/88283711375#step:5:116 ) caused by a mismatch in the directive order of the `content-security-policy` header. `helmet` (`^8.0.0`, resolved to `8.3.0`) changed the internal serialization order of default CSP directives. The resulting header is semantically identical — only the order changed, which has no meaning per the CSP spec.
- Updated the expected header string in the test to match the new order.

